### PR TITLE
When Gemini fails, fall back to configured model.

### DIFF
--- a/utils/llm.py
+++ b/utils/llm.py
@@ -255,26 +255,25 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
         # {"provider": "openai", "model": "gpt-4o-2024-05-13"},
     ]
 
-    routed_model = route_llm_prompt(text, instructions, llm_providers, source_langage, target_language)
+    nd_routed_model = route_llm_prompt(text, instructions, llm_providers, source_langage, target_language)
 
-    if routed_model == "gemini-1.5-flash-latest":
+    if nd_routed_model in ["gemini-1.5-flash-latest", "gemini-1.5-pro-latest"]:
         chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
-        response = send_to_gemini(chunks[0], instructions, model_id=routed_model)
-    elif routed_model == "claude-3-haiku-20240307":
+        # Google Gemini can occasionally return empty responses - handle this with retries and,
+        # if necessary, fallback to the configured default model
+        try:
+            response = send_to_gemini(chunks[0], instructions, model_id=nd_routed_model)
+        except RuntimeError as e:
+            logging.error(f"Error sending task to {nd_routed_model}. Falling back to {model}. {e}")
+            response = fetch_llm_response_fallback(text, instructions, model, nd_routed_model)
+    elif nd_routed_model == "claude-3-haiku-20240307":
         chunks = text_to_chunks(text,chunk_size=(190000-len(instructions)))
         response = send_to_anthropic(chunks[0], instructions,'claude-3-haiku-20240307')
+    elif nd_routed_model == "gpt-4o-2024-05-13":
+        chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
+        response = send_to_openai(chunks[0],instructions,'gpt-4o-2024-05-13')
     else:
-        if model == "Claude 3h":
-            chunks = text_to_chunks(text,chunk_size=(190000-len(instructions)))
-            response = send_to_anthropic(chunks[0], instructions,'claude-3-haiku-20240307')
-        elif model == "GPT-4o":
-            chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
-            response = send_to_openai(chunks[0],instructions,'gpt-4o')
-        elif model == "Open Mixtral":
-            chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
-            response = send_to_mistral(chunks[0], instructions,'open-mixtral-8x7b')
-        else:
-            raise UnsupportedModelException(f"Provided model={model}, ND routed model={routed_model}")
+        response = fetch_llm_response_fallback(text, instructions, model, nd_routed_model)
 
     if validation is None:
         return response, model
@@ -294,3 +293,17 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
         return find_json(response), model
     else:
         raise UnsupportedValidationException(validation)
+
+def fetch_llm_response_fallback(text, instructions, model, routed_model):
+    if model == "Claude 3h":
+        chunks = text_to_chunks(text,chunk_size=(190000-len(instructions)))
+        response = send_to_anthropic(chunks[0], instructions,'claude-3-haiku-20240307')
+    elif model == "GPT-4o":
+        chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
+        response = send_to_openai(chunks[0],instructions,'gpt-4o')
+    elif model == "Open Mixtral":
+        chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
+        response = send_to_mistral(chunks[0], instructions,'open-mixtral-8x7b')
+    else:
+        raise UnsupportedModelException(f"Provided model={model}, ND routed model={routed_model}")
+    return response

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -264,10 +264,10 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
         # if necessary, fallback to the configured default model
         try:
             response = send_to_gemini(chunks[0], instructions, model_id=nd_routed_model)
+            nd_routing = True
         except RuntimeError as e:
             logging.error(f"Error sending task to {nd_routed_model}. Falling back to {model}. {e}")
             response = fetch_llm_response_fallback(text, instructions, model, nd_routed_model)
-        nd_routing = True
     elif nd_routed_model == "claude-3-haiku-20240307":
         chunks = text_to_chunks(text,chunk_size=(190000-len(instructions)))
         response = send_to_anthropic(chunks[0], instructions,'claude-3-haiku-20240307')

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -257,6 +257,7 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
 
     nd_routed_model = route_llm_prompt(text, instructions, llm_providers, source_langage, target_language)
 
+    nd_routing = False
     if nd_routed_model in ["gemini-1.5-flash-latest", "gemini-1.5-pro-latest"]:
         chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
         # Google Gemini can occasionally return empty responses - handle this with retries and,
@@ -266,14 +267,20 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
         except RuntimeError as e:
             logging.error(f"Error sending task to {nd_routed_model}. Falling back to {model}. {e}")
             response = fetch_llm_response_fallback(text, instructions, model, nd_routed_model)
+        nd_routing = True
     elif nd_routed_model == "claude-3-haiku-20240307":
         chunks = text_to_chunks(text,chunk_size=(190000-len(instructions)))
         response = send_to_anthropic(chunks[0], instructions,'claude-3-haiku-20240307')
+        nd_routing = True
     elif nd_routed_model == "gpt-4o-2024-05-13":
         chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
         response = send_to_openai(chunks[0],instructions,'gpt-4o-2024-05-13')
+        nd_routing = True
     else:
         response = fetch_llm_response_fallback(text, instructions, model, nd_routed_model)
+
+    if nd_routing:
+        model = nd_routed_model
 
     if validation is None:
         return response, model


### PR DESCRIPTION
We know Gemini can fail - if that happens, let's make sure to use the configured model instead.