### PR TITLE
Confirm article summary lengths before publishing summaries.

### DIFF
--- a/utils/llm.py
+++ b/utils/llm.py
@@ -292,7 +292,7 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
         article_summary = find_article_content(soup, min_article_score)
         summary_length = len(article_summary.text.strip().split(' '))
 
-    if not nd_routing or (validation == 'html-article' and (summary_length > 250 or summary_length < 50)):
+    if not nd_routing or (validation == 'html-article' and (summary_length > 150 or summary_length < 50)):
         log_msg = f"Falling back to {model}."
         if validation == 'html-article':
             log_msg = f"Article summary length: {summary_length} " + log_msg

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -91,18 +91,8 @@ def validate_article_html(html, language_code, min_article_score, model):
             if attr not in allowed_attributes:
                 del tag[attr]
 
-    article_div = soup.find('div', class_='article',\
-            attrs=lambda attrs: 'data-front-page-score'\
-            in attrs and min_article_score <= int(attrs['data-front-page-score']) <= 5)
-    if not article_div:
-        return False
-
-    article_title_div = article_div.find('div', class_='article-title')
-    if not article_title_div:
-        return False
-
-    article_content = article_div.find('div', class_='article-content hidden')
-    if not article_content:
+    article_content = find_article_content(soup, min_article_score)
+    if article_content is None:
         return False
 
     content_text = article_content.text.strip()
@@ -115,6 +105,19 @@ def validate_article_html(html, language_code, min_article_score, model):
         return False
 
     return True
+
+def find_article_content(soup, min_article_score):
+
+    article_content = None
+    article_div = soup.find('div', class_='article',\
+            attrs=lambda attrs: 'data-front-page-score'\
+            in attrs and min_article_score <= int(attrs['data-front-page-score']) <= 5)
+    if article_div:
+        article_title_div = article_div.find('div', class_='article-title')
+        if article_title_div:
+            article_content = article_div.find('div', class_='article-content hidden')
+
+    return article_content
 
 
 def find_json(text):
@@ -263,7 +266,7 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
 
     nd_routing = False
     if nd_routed_model in ["gemini-1.5-flash-latest", "gemini-1.5-pro-latest"]:
-        chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
+        chunks = text_to_chunks(text,chunk_size=(190000-len(instructions)))
         # Google Gemini can occasionally return empty responses - handle this with retries and,
         # if necessary, fallback to the configured default model
         try:
@@ -280,8 +283,18 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
         chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
         response = send_to_openai(chunks[0],instructions,'gpt-4o-2024-05-13')
         nd_routing = True
-    else:
+
+    # Fallbacks:
+    # - Check the summary. Too long?
+    # - Routing failed?
+    if validation == 'html-article':
+        soup = BeautifulSoup(response, 'html.parser')
+        article_summary = find_article_content(soup, min_article_score)
+        summary_length = len(' '.split(article_summary.text.strip()))
+
+    if not nd_routing or (validation == 'html-article' and (summary_length > 150 or summary_length < 50)):
         response = fetch_llm_response_fallback(text, instructions, model, nd_routed_model)
+        nd_routing = False
 
     if nd_routing:
         model = nd_routed_model

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -290,9 +290,13 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
     if validation == 'html-article':
         soup = BeautifulSoup(response, 'html.parser')
         article_summary = find_article_content(soup, min_article_score)
-        summary_length = len(' '.split(article_summary.text.strip()))
+        summary_length = len(article_summary.text.strip().split(' '))
 
-    if not nd_routing or (validation == 'html-article' and (summary_length > 150 or summary_length < 50)):
+    if not nd_routing or (validation == 'html-article' and (summary_length > 250 or summary_length < 50)):
+        log_msg = f"Falling back to {model}."
+        if validation == 'html-article':
+            log_msg = f"Article summary length: {summary_length} " + log_msg
+        logging.info(log_msg)
         response = fetch_llm_response_fallback(text, instructions, model, nd_routed_model)
         nd_routing = False
 

--- a/utils/llm.py
+++ b/utils/llm.py
@@ -266,7 +266,7 @@ def fetch_llm_response(text, instructions, model, validation=None, language_filt
 
     nd_routing = False
     if nd_routed_model in ["gemini-1.5-flash-latest", "gemini-1.5-pro-latest"]:
-        chunks = text_to_chunks(text,chunk_size=(190000-len(instructions)))
+        chunks = text_to_chunks(text,chunk_size=(31000-len(instructions)))
         # Google Gemini can occasionally return empty responses - handle this with retries and,
         # if necessary, fallback to the configured default model
         try:

--- a/utils/publisher.py
+++ b/utils/publisher.py
@@ -285,6 +285,7 @@ if __name__ == "__main__":
     if debug:
         deploy_language("Arabic")
         deploy_language("English")
+        deploy_language("Hungarian")
     else:
         with open('config/languages.json', 'r') as file:
             lang_configs = json.load(file)


### PR DESCRIPTION
If a summary runs too short or long, we rely on the fallback model instead.